### PR TITLE
Added an extension method to handle .Net Core drivers ArrayList.

### DIFF
--- a/ASCOM.DriverAccess/ASCOM.DriverAccess.csproj
+++ b/ASCOM.DriverAccess/ASCOM.DriverAccess.csproj
@@ -115,6 +115,7 @@
     </Compile>
     <Compile Include="Dome.cs">
     </Compile>
+    <Compile Include="Extensions.cs" />
     <Compile Include="FilterWheel.cs">
     </Compile>
     <Compile Include="Focuser.cs">

--- a/ASCOM.DriverAccess/AscomDriver.cs
+++ b/ASCOM.DriverAccess/AscomDriver.cs
@@ -412,7 +412,7 @@ namespace ASCOM.DriverAccess
             {
                 try
                 {
-                    return (ArrayList)memberFactory.CallMember(1, "SupportedActions", new Type[] { }, new object[] { });
+                    return memberFactory.CallMember(1, "SupportedActions", new Type[] { }, new object[] { }).ComObjToArrayList();
                 }
                 catch (Exception ex)
                 {

--- a/ASCOM.DriverAccess/Camera.cs
+++ b/ASCOM.DriverAccess/Camera.cs
@@ -859,7 +859,7 @@ namespace ASCOM.DriverAccess
         /// </remarks>
         public ArrayList Gains
         {
-            get { return (ArrayList)_memberFactory.CallMember(1, "Gains", new Type[] { }, new object[] { }); }
+            get { return _memberFactory.CallMember(1, "Gains", new Type[] { }, new object[] { }).ComObjToArrayList(); }
         }
 
         /// <summary>
@@ -933,7 +933,7 @@ namespace ASCOM.DriverAccess
         /// </remarks>
         public ArrayList ReadoutModes
         {
-            get { return (ArrayList)_memberFactory.CallMember(1, "ReadoutModes", new Type[] { }, new object[] { }); }
+            get { return _memberFactory.CallMember(1, "ReadoutModes", new Type[] { }, new object[] { }).ComObjToArrayList(); }
         }
 
         /// <summary>

--- a/ASCOM.DriverAccess/Extensions.cs
+++ b/ASCOM.DriverAccess/Extensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ASCOM.DriverAccess
+{
+    internal static class Extensions
+    {
+        internal static ArrayList ToArrayList(this IEnumerable enumerable)
+        {
+            var templist = new ArrayList();
+
+            foreach (var item in enumerable)
+            {
+                templist.Add(item);
+            }
+            return templist;
+        }
+
+        internal static ArrayList ComObjToArrayList(this object obj)
+        {
+            return obj as ArrayList ?? ((IEnumerable)obj).ToArrayList();
+        }
+    }
+}

--- a/ASCOM.DriverAccess/Video.cs
+++ b/ASCOM.DriverAccess/Video.cs
@@ -114,7 +114,7 @@ namespace ASCOM.DriverAccess
         /// <exception cref="PropertyNotImplementedException">Must throw exception if camera supports only one integration rate (exposure) that cannot be changed.</exception>
         public ArrayList SupportedIntegrationRates
         {
-            get { return (ArrayList)memberFactory.CallMember(1, "SupportedIntegrationRates", new Type[0], new object[0]); }
+            get { return memberFactory.CallMember(1, "SupportedIntegrationRates", new Type[0], new object[0]).ComObjToArrayList(); }
         }
 
         /// <summary>
@@ -662,7 +662,7 @@ namespace ASCOM.DriverAccess
         ///	</remarks>
         public ArrayList Gains
         {
-            get { return (ArrayList)memberFactory.CallMember(1, "Gains", new Type[0], new object[0]); }
+            get { return memberFactory.CallMember(1, "Gains", new Type[0], new object[0]).ComObjToArrayList(); }
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace ASCOM.DriverAccess
         ///	</remarks>	
         public ArrayList Gammas
         {
-            get { return (ArrayList)memberFactory.CallMember(1, "Gammas", new Type[0], new object[0]); }
+            get { return memberFactory.CallMember(1, "Gammas", new Type[0], new object[0]).ComObjToArrayList(); }
         }
 
         /// <summary>


### PR DESCRIPTION
Net Core 3.0 ArrayLists are not COM Visible so direct casting does not work. The extension method checks if the com object can be directly cast to an ArrayList and if it can not it iterates over the IEnumerable and converts it to an array list.
I tested this on my .Net Core drivers (A simulator is available here: https://github.com/DanielVanNoord/TelescopeSimulator-Core) and several existing NetFX drivers and it seems to work without issue. Others should test this with their drivers.